### PR TITLE
Extend provider configuration with new options and add ability to filter autocomplete results before rendering

### DIFF
--- a/src/components/AutosuggestField/AutosuggestField.js
+++ b/src/components/AutosuggestField/AutosuggestField.js
@@ -16,7 +16,7 @@ const AutosuggestField = ({
 	name,
 	minSearchCharacters,
 	searchTerm,
-	resultFilter,
+	onItemRender,
 }) => {
 	const {
 		state: { search, results },
@@ -52,7 +52,7 @@ const AutosuggestField = ({
 									setFocus={setFocus}
 									index={index}
 									focus={focus === index}
-									result={resultFilter(result)}
+									result={onItemRender(result)}
 								/>
 							);
 						})}
@@ -69,7 +69,7 @@ AutosuggestField.defaultProps = {
 	initialValue: '',
 	minSearchCharacters: 3,
 	searchTerm: '',
-	resultFilter: (item) => item,
+	onItemRender: (item) => item,
 };
 
 AutosuggestField.propTypes = {
@@ -78,7 +78,7 @@ AutosuggestField.propTypes = {
 	placeholder: PropTypes.string,
 	minSearchCharacters: PropTypes.number,
 	searchTerm: PropTypes.string,
-	resultFilter: PropTypes.func,
+	onItemRender: PropTypes.func,
 };
 
 export default AutosuggestField;

--- a/src/components/AutosuggestField/AutosuggestField.js
+++ b/src/components/AutosuggestField/AutosuggestField.js
@@ -10,7 +10,14 @@ import useRoveFocus from '../../hooks/useRoveFocus';
 import { useElasticPress } from '../../hooks';
 import SearchField from '../SearchField/SearchField';
 
-const AutosuggestField = ({ initialValue, placeholder, name, minSearchCharacters }) => {
+const AutosuggestField = ({
+	initialValue,
+	placeholder,
+	name,
+	minSearchCharacters,
+	searchTerm,
+	resultFilter,
+}) => {
 	const {
 		state: { search, results },
 	} = useElasticPress();
@@ -33,6 +40,7 @@ const AutosuggestField = ({ initialValue, placeholder, name, minSearchCharacters
 				placeholder={placeholder}
 				minSearchCharacters={minSearchCharacters}
 				ref={inputRef}
+				searchTerm={searchTerm}
 			/>
 			{results?.items?.length > 0 && (
 				<div className={`${styles.dropdownContainer} ep-autosuggest`}>
@@ -44,7 +52,7 @@ const AutosuggestField = ({ initialValue, placeholder, name, minSearchCharacters
 									setFocus={setFocus}
 									index={index}
 									focus={focus === index}
-									result={result}
+									result={resultFilter(result)}
 								/>
 							);
 						})}
@@ -60,6 +68,8 @@ AutosuggestField.defaultProps = {
 	placeholder: 'Search...',
 	initialValue: '',
 	minSearchCharacters: 3,
+	searchTerm: '',
+	resultFilter: (item) => item,
 };
 
 AutosuggestField.propTypes = {
@@ -67,6 +77,8 @@ AutosuggestField.propTypes = {
 	initialValue: PropTypes.string,
 	placeholder: PropTypes.string,
 	minSearchCharacters: PropTypes.number,
+	searchTerm: PropTypes.string,
+	resultFilter: PropTypes.func,
 };
 
 export default AutosuggestField;

--- a/src/components/AutosuggestField/AutosuggestField.js
+++ b/src/components/AutosuggestField/AutosuggestField.js
@@ -17,6 +17,7 @@ const AutosuggestField = ({
 	minSearchCharacters,
 	searchTerm,
 	onItemRender,
+	collapsed,
 }) => {
 	const {
 		state: { search, results },
@@ -42,7 +43,7 @@ const AutosuggestField = ({
 				ref={inputRef}
 				searchTerm={searchTerm}
 			/>
-			{results?.items?.length > 0 && (
+			{!collapsed && results?.items?.length > 0 && (
 				<div className={`${styles.dropdownContainer} ep-autosuggest`}>
 					<ul className={`${styles.dropdownList} autosuggest-list`} role="listbox">
 						{results?.items?.map((result, index) => {
@@ -70,6 +71,7 @@ AutosuggestField.defaultProps = {
 	minSearchCharacters: 3,
 	searchTerm: '',
 	onItemRender: (item) => item,
+	collapsed: false,
 };
 
 AutosuggestField.propTypes = {
@@ -79,6 +81,7 @@ AutosuggestField.propTypes = {
 	minSearchCharacters: PropTypes.number,
 	searchTerm: PropTypes.string,
 	onItemRender: PropTypes.func,
+	collapsed: PropTypes.bool,
 };
 
 export default AutosuggestField;

--- a/src/components/Provider/ElasticPressProvider.js
+++ b/src/components/Provider/ElasticPressProvider.js
@@ -43,6 +43,7 @@ const ElasticPressProvider = ({
 	children,
 	node,
 	indexName,
+	endpoint,
 	hitMap,
 	loadInitialData,
 	searchState,
@@ -71,15 +72,17 @@ const ElasticPressProvider = ({
 			return getESEndpoint(type, {
 				node,
 				indexName,
+				endpoint,
 			});
 		},
-		[indexName, node],
+		[indexName, node, endpoint],
 	);
 
 	const contextValue = {
 		node,
 		indexName,
 		loadInitialData,
+		endpoint,
 		state,
 		hitMap,
 		query,
@@ -109,6 +112,7 @@ ElasticPressProvider.propTypes = {
 	query: PropTypes.object,
 	node: PropTypes.string.isRequired,
 	indexName: PropTypes.string.isRequired,
+	endpoint: PropTypes.string,
 	onSSR: PropTypes.func,
 	onSearch: PropTypes.func,
 };
@@ -123,6 +127,7 @@ ElasticPressProvider.defaultProps = {
 	loadInitialData: true,
 	onSSR: null,
 	onSearch: () => {},
+	endpoint: '/_doc/_search',
 };
 
 export default ElasticPressProvider;

--- a/src/components/SearchField/SearchField.js
+++ b/src/components/SearchField/SearchField.js
@@ -9,7 +9,7 @@ import { useSearch } from '../../hooks';
 
 const SearchField = React.forwardRef(
 	({ placeholder, initialValue, name, minSearchCharacters, debounceMs, searchTerm }, ref) => {
-		const [localSearchTerm, setLocalSearchTerm] = useState(searchTerm);
+		const [localSearchTerm, setLocalSearchTerm] = useState('');
 		const { refine } = useSearch();
 
 		const search = useCallback(
@@ -22,6 +22,10 @@ const SearchField = React.forwardRef(
 			),
 			[refine, minSearchCharacters, debounceMs],
 		);
+
+		useEffect(() => {
+			setLocalSearchTerm(searchTerm);
+		}, [searchTerm]);
 
 		// search if a initial value is provided from parent component
 		useEffect(() => {

--- a/src/components/SearchField/SearchField.js
+++ b/src/components/SearchField/SearchField.js
@@ -8,8 +8,8 @@ import debounce from 'lodash.debounce';
 import { useSearch } from '../../hooks';
 
 const SearchField = React.forwardRef(
-	({ placeholder, initialValue, name, minSearchCharacters, debounceMs }, ref) => {
-		const [localSearchTerm, setLocalSearchTerm] = useState('');
+	({ placeholder, initialValue, name, minSearchCharacters, debounceMs, searchTerm }, ref) => {
+		const [localSearchTerm, setLocalSearchTerm] = useState(searchTerm);
 		const { refine } = useSearch();
 
 		const search = useCallback(
@@ -54,6 +54,7 @@ SearchField.defaultProps = {
 	initialValue: '',
 	minSearchCharacters: 3,
 	debounceMs: 0,
+	searchTerm: '',
 };
 
 SearchField.propTypes = {
@@ -62,6 +63,7 @@ SearchField.propTypes = {
 	placeholder: PropTypes.string,
 	minSearchCharacters: PropTypes.number,
 	debounceMs: PropTypes.number,
+	searchTerm: PropTypes.string,
 };
 
 export default SearchField;

--- a/src/utils/getESEndpoint.js
+++ b/src/utils/getESEndpoint.js
@@ -10,10 +10,10 @@
  * @returns {string}
  */
 export default (type = 'search', config) => {
-	const { node, indexName } = config;
+	const { node, indexName, endpoint } = config;
 
 	if (type === 'search' && !node.includes('elasticpress.io')) {
-		return `${node}/${indexName}/_doc/_search`;
+		return `${node}/${indexName}${endpoint}`;
 	}
 
 	if (type === 'search' && node.includes('elasticpress.io')) {

--- a/src/utils/getESEndpoint.js
+++ b/src/utils/getESEndpoint.js
@@ -10,7 +10,7 @@
  * @returns {string}
  */
 export default (type = 'search', config) => {
-	const { node, indexName, endpoint } = config;
+	const { node, indexName, endpoint = '/_doc/_search' } = config;
 
 	if (type === 'search' && !node.includes('elasticpress.io')) {
 		return `${node}/${indexName}${endpoint}`;


### PR DESCRIPTION
### Description of the Change

This PR contains changes that:
- allow control Autocomplete / Search a bit more by exposing options to configure EP endpoint 
- modify autocomplete result before rendering in the list
- fixes some issues with initial state when Autocomplete is also used as default input for classic website search

### Alternate Designs

### Benefits

Projects will be able to better adjust ElasticPress React integration configuration and UI behaviour.

### Possible Drawbacks


### Verification Process

Introduced changes were tested on a client project and their behaviour (results links change, initial search term state, modified EP endpoint) was validated correctly.

### Checklist:

- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

### Changelog Entry
