### PR TITLE
Expose provider actions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import RelatedContent from './components/RelatedContent/RelatedContent';
 import { SearchField } from './components/SearchField';
 import Posts from './components/Posts/Posts';
 import { ElasticPressProvider } from './components/Provider';
+import * as ProviderActions from './components/Provider/actions';
 import { useElasticPress, useSearch } from './hooks';
 import { findResultsState } from './server';
 import { buildQuery, runEPQuery, getESEndpoint } from './utils';
@@ -13,6 +14,7 @@ export {
 	RelatedContent,
 	SearchField,
 	ElasticPressProvider,
+	ProviderActions,
 	useElasticPress,
 	useSearch,
 	Posts,


### PR DESCRIPTION
We are working on a feature where we need to have different post types for each of the queries we do. Because of that, we'll need to reimplement the `useSearch` hook with the "low-level" API. The only thing that we need to accomplish this and is not exposed yet are the actions.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
